### PR TITLE
i16 fix camping utica reservoir page incorrect image links

### DIFF
--- a/camping-fun/camping-at-stanislaus-national-forest-utica-reservoir.html
+++ b/camping-fun/camping-at-stanislaus-national-forest-utica-reservoir.html
@@ -309,7 +309,7 @@
     <p>
       Picture showing the parking spot and camping spot:<br>
       <br>
-      <img src="/images/Utica Reservoir Parking Spot & Approximate Camping Spot.jpg" alt="Utica Reservoir Parking Spot & Approximate Camping Spot" class="img-thumbnail">
+      <img src="/images/Utica Reservoir Parking Spot & Approximate Camping Spot.JPG" alt="Utica Reservoir Parking Spot & Approximate Camping Spot" class="img-thumbnail">
     </p>
 
     <h2>Hiking to the Campsite</h2>
@@ -332,7 +332,7 @@
     <p>
       Following is a picture of our favorite camping spots:<br>
       <br>
-      <img src="/images/Utica Reservoir Camping Spots.jpg" alt="Utica Reservoir Parking Spot & Approximate Camping Spot.jpg" class="img-thumbnail">
+      <img src="/images/Utica Reservoir Camping Spots.JPG" alt="Utica Reservoir Camping Spots" class="img-thumbnail">
     </p>
 
     <h2>Lunch in Angels Camp</h2>


### PR DESCRIPTION
# Description

This pull request is for issue #16 to fix PR #19 which introduced incorrect image links for page _camping-fun/camping-at-stanislaus-national-forest-utica-reservoir.html_:

- _/images/Utica Reservoir Camping Spots.jpg_ -> _/images/Utica Reservoir Camping Spots.JPG_
- _/images/Utica Reservoir Parking Spot & Approximate Camping Spot.jpg_ -> _/images/Utica Reservoir Parking Spot & Approximate Camping Spot.JPG_