### PR TITLE
i16 fix incorrect titles for camping pages: camping fun, camping checklist, camping utica reservoir

### DIFF
--- a/camping-fun.html
+++ b/camping-fun.html
@@ -6,7 +6,7 @@
     <meta name="description" content="JN Family Camping Fun">
     <meta name="author" content="JN Parents">
 
-    <title>JN Family Biking Fun</title>
+    <title>JN Family Camping Fun</title>
     
     <!-- Bootstrap CSSs and JN Family's custom override CSS -->
     <link rel="stylesheet" href="/assets/dist/css/bootstrap.min.css">

--- a/camping-fun/camping-at-stanislaus-national-forest-utica-reservoir.html
+++ b/camping-fun/camping-at-stanislaus-national-forest-utica-reservoir.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Camping at Stanislaus National Forest Utica Reservoir">
   <meta name="author" content="JN Parents">
 
-  <title>Bike Ride Almaden to Willow Glen</title>
+  <title>Camping at Stanislaus National Forest (Utica Reservoir)</title>
 
   <!-- Bootstrap CSSs and JN Family's custom override CSS -->
   <link rel="stylesheet" href="/assets/dist/css/bootstrap.min.css">

--- a/camping-fun/camping-checklist.html
+++ b/camping-fun/camping-checklist.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Camping Checklist">
   <meta name="author" content="JN Parents">
 
-  <title>Bike Ride Almaden to Willow Glen</title>
+  <title>Camping Checklist</title>
 
   <!-- Bootstrap CSSs and JN Family's custom override CSS -->
   <link rel="stylesheet" href="/assets/dist/css/bootstrap.min.css">


### PR DESCRIPTION
# Description

This pull request is for issue #16 PR #19 which used incorrect Title tag content for the following pages:
- _camping-fun.html_
- _camping-fun/camping-at-stanislaus-national-forest-utica-reservoir.html_
- _camping-fun/camping-checklist.html_